### PR TITLE
Allegro publishing speed up with multithreading approach

### DIFF
--- a/saleor/plugins/allegro/tasks.py
+++ b/saleor/plugins/allegro/tasks.py
@@ -5,7 +5,6 @@ from ...celeryconf import app
 logger = logging.getLogger(__name__)
 from saleor.plugins.allegro import ProductPublishState
 
-@app.task
 def async_product_publish(allegro_api_instance, saleor_product, offer_type, starting_at, parameters_mapper_factory, product_mapper_factory):
     return _product_publish(allegro_api_instance, saleor_product, offer_type, starting_at, parameters_mapper_factory, product_mapper_factory)
 


### PR DESCRIPTION
Do not merge for production, only for testing purposes. Sending email with errors list turned off. Publishing to allegro function switched from Celery to multithreading. There's need to test it more in local environment.

Benchmarks for publishing 100 items:
- Celery synchronous: 360s
- Multithreading: 30s