### PR TITLE
Set default variant on ProductCreate mutation

### DIFF
--- a/saleor/graphql/product/mutations/products.py
+++ b/saleor/graphql/product/mutations/products.py
@@ -1010,6 +1010,8 @@ class ProductCreate(ModelMutation):
                 sku=sku,
                 price_amount=variant_price,
             )
+            instance.default_variant = variant
+            instance.save()
             stocks = cleaned_input.get("stocks")
             if stocks:
                 cls.create_variant_stocks(variant, stocks)


### PR DESCRIPTION
I want to merge this change because...

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
